### PR TITLE
Add core model scaffolding with SGD optimizer and MSE loss

### DIFF
--- a/src/activation/activation.hpp
+++ b/src/activation/activation.hpp
@@ -1,13 +1,19 @@
 #ifndef THOT_ACTIVATION_HPP
 #define THOT_ACTIVATION_HPP
-// This file is an factory, must exempt it from any logical-code. For functions look into "/details"
-
-#include "activation/details/relu.hpp"
+// This file is a factory, must exempt it from any logical-code. For functions look into "/details"
 
 namespace Thot::Activation {
-    [[nodiscard]] constexpr auto make_relu() -> ::Thot::Activation::Details::ReLU {
-        return {};
-    }
+    enum class Type {
+        Identity,
+        ReLU,
+    };
+
+    struct Descriptor {
+        Type type{Type::Identity};
+    };
+
+    inline constexpr Descriptor Identity{Type::Identity};
+    inline constexpr Descriptor ReLU{Type::ReLU};
 }
 
 #endif //THOT_ACTIVATION_HPP

--- a/src/activation/details/relu.hpp
+++ b/src/activation/details/relu.hpp
@@ -1,4 +1,30 @@
 #ifndef THOT_RELU_HPP
 #define THOT_RELU_HPP
 
+#include <torch/torch.h>
+
+#include <utility>
+
+#include "activation/activation.hpp"
+
+namespace Thot::Activation::Details {
+
+struct ReLU {
+    [[nodiscard]] torch::Tensor operator()(torch::Tensor input) const {
+        return torch::relu(std::move(input));
+    }
+};
+
+inline torch::Tensor apply(::Thot::Activation::Type type, torch::Tensor input) {
+    switch (type) {
+        case ::Thot::Activation::Type::ReLU:
+            return ReLU{}(std::move(input));
+        case ::Thot::Activation::Type::Identity:
+        default:
+            return input;
+    }
+}
+
+}  // namespace Thot::Activation::Details
+
 #endif //THOT_RELU_HPP

--- a/src/core.hpp
+++ b/src/core.hpp
@@ -21,13 +21,124 @@
  *    monitoring routines pre-bound to the compile-time configuration.
  */
 
-// Upcoming API sketch (to be refined during implementation):
-// namespace Thot::Core {
-//     struct CompileTimeConfig;          // constexpr description of enabled features
-//     constexpr auto make_runtime();     // builds the aggregate runtime facade
-//     constexpr auto make_network();     // prepares callable forward/backward functions
-//     constexpr auto make_trainer();     // orchestrates epoch/mini-batch execution
-//     constexpr auto make_evaluator();   // returns evaluation functors
-// }
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <torch/torch.h>
+
+#include "activation/activation.hpp"
+#include "activation/details/relu.hpp"
+#include "initialization/initialization.hpp"
+#include "layer/layer.hpp"
+#include "loss/loss.hpp"
+#include "loss/details/mse.hpp"
+#include "optimizer/optimizer.hpp"
+#include "optimizer/details/sgd.hpp"
+
+namespace Thot {
+
+class Model : public torch::nn::Module {
+public:
+    Model() = default;
+
+    void add(const Layer::FCDescriptor& descriptor) {
+        if (descriptor.options.in_features <= 0 || descriptor.options.out_features <= 0) {
+            throw std::invalid_argument("Fully connected layers require positive in/out features.");
+        }
+        const auto index = dense_layers_.size();
+        auto options = torch::nn::LinearOptions(descriptor.options.in_features,
+                                                descriptor.options.out_features)
+                            .bias(descriptor.options.bias);
+        auto layer = register_module("fc_" + std::to_string(index), torch::nn::Linear(options));
+        apply_initialization(layer, descriptor);
+        dense_layers_.push_back(DenseLayer{layer, descriptor.activation.type});
+    }
+
+    void set_optimizer(const Optimizer::SGDDescriptor& descriptor) {
+        if (dense_layers_.empty()) {
+            throw std::logic_error("Cannot create optimizer before any layer has been registered.");
+        }
+        auto options = Optimizer::Details::to_torch_options(descriptor.options);
+        optimizer_ = std::make_unique<torch::optim::SGD>(this->parameters(), options);
+    }
+
+    void set_loss(const Loss::MSEDescriptor& descriptor) {
+        loss_descriptor_ = descriptor;
+    }
+
+    [[nodiscard]] torch::Tensor forward(torch::Tensor input) {
+        auto output = std::move(input);
+        for (auto& layer : dense_layers_) {
+            output = layer.linear->forward(output);
+            output = Activation::Details::apply(layer.activation, std::move(output));
+        }
+        return output;
+    }
+
+    [[nodiscard]] torch::Tensor compute_loss(const torch::Tensor& prediction,
+                                             const torch::Tensor& target,
+                                             const std::optional<torch::Tensor>& weight = std::nullopt) const {
+        if (!loss_descriptor_.has_value()) {
+            throw std::logic_error("Loss function has not been configured.");
+        }
+        return Loss::Details::compute(*loss_descriptor_, prediction, target, weight);
+    }
+
+    void zero_grad() {
+        if (optimizer_) {
+            optimizer_->zero_grad();
+        } else {
+            torch::nn::Module::zero_grad();
+        }
+    }
+
+    void step() {
+        if (!optimizer_) {
+            throw std::logic_error("Optimizer has not been configured.");
+        }
+        optimizer_->step();
+    }
+
+    [[nodiscard]] bool has_optimizer() const noexcept { return static_cast<bool>(optimizer_); }
+
+    [[nodiscard]] bool has_loss() const noexcept { return loss_descriptor_.has_value(); }
+
+    [[nodiscard]] torch::optim::Optimizer& optimizer() {
+        if (!optimizer_) {
+            throw std::logic_error("Optimizer has not been configured.");
+        }
+        return *optimizer_;
+    }
+
+private:
+    struct DenseLayer {
+        torch::nn::Linear linear{nullptr};
+        Activation::Type activation{Activation::Type::Identity};
+    };
+
+    static void apply_initialization(const torch::nn::Linear& layer, const Layer::FCDescriptor& descriptor) {
+        switch (descriptor.initialization.type) {
+            case Initialization::Type::XavierNormal:
+                torch::nn::init::xavier_normal_(layer->weight);
+                if (descriptor.options.bias && layer->bias.defined()) {
+                    torch::nn::init::zeros_(layer->bias);
+                }
+                break;
+            case Initialization::Type::Default:
+            default:
+                break;
+        }
+    }
+
+    std::vector<DenseLayer> dense_layers_{};
+    std::unique_ptr<torch::optim::Optimizer> optimizer_{};
+    std::optional<Loss::MSEDescriptor> loss_descriptor_{};
+};
+
+}  // namespace Thot
 
 #endif //THOT_CORE_HPP

--- a/src/initialization/initialization.hpp
+++ b/src/initialization/initialization.hpp
@@ -1,5 +1,19 @@
 #ifndef THOT_INITIALIZATION_HPP
 #define THOT_INITIALIZATION_HPP
-// This file is an factory, must exempt it from any logical-code. For functions look into "/details"
+// This file is a factory, must exempt it from any logical-code. For functions look into "/details"
+
+namespace Thot::Initialization {
+    enum class Type {
+        Default,
+        XavierNormal,
+    };
+
+    struct Descriptor {
+        Type type{Type::Default};
+    };
+
+    inline constexpr Descriptor Default{Type::Default};
+    inline constexpr Descriptor XavierNormal{Type::XavierNormal};
+}
 
 #endif //THOT_INITIALIZATION_HPP

--- a/src/layer/details/fc.hpp
+++ b/src/layer/details/fc.hpp
@@ -1,4 +1,25 @@
 #ifndef THOT_FC_HPP
 #define THOT_FC_HPP
 
+#include <cstdint>
+
+#include "activation/activation.hpp"
+#include "initialization/initialization.hpp"
+
+namespace Thot::Layer::Details {
+
+struct FCOptions {
+    std::int64_t in_features{};
+    std::int64_t out_features{};
+    bool bias{true};
+};
+
+struct FCDescriptor {
+    FCOptions options;
+    ::Thot::Activation::Descriptor activation{::Thot::Activation::Identity};
+    ::Thot::Initialization::Descriptor initialization{::Thot::Initialization::Default};
+};
+
+}  // namespace Thot::Layer::Details
+
 #endif //THOT_FC_HPP

--- a/src/layer/layer.hpp
+++ b/src/layer/layer.hpp
@@ -1,6 +1,19 @@
 #ifndef THOT_LAYER_HPP
 #define THOT_LAYER_HPP
-// This file is an factory, must exempt it from any logical-code. For functions look into "/details"
+// This file is a factory, must exempt it from any logical-code. For functions look into "/details"
 
+#include "layer/details/fc.hpp"
+
+namespace Thot::Layer {
+    using FCOptions = Details::FCOptions;
+    using FCDescriptor = Details::FCDescriptor;
+
+    [[nodiscard]] constexpr auto FC(const FCOptions& options,
+                                    ::Thot::Activation::Descriptor activation = ::Thot::Activation::Identity,
+                                    ::Thot::Initialization::Descriptor initialization = ::Thot::Initialization::Default)
+        -> FCDescriptor {
+        return {options, activation, initialization};
+    }
+}
 
 #endif //THOT_LAYER_HPP

--- a/src/loss/details/mse.hpp
+++ b/src/loss/details/mse.hpp
@@ -1,4 +1,54 @@
 #ifndef THOT_MSE_HPP
 #define THOT_MSE_HPP
 
+#include <optional>
+#include <stdexcept>
+#include <torch/torch.h>
+
+namespace Thot::Loss::Details {
+
+enum class Reduction {
+    Mean,
+    Sum,
+    None,
+};
+
+inline constexpr torch::Reduction to_torch_reduction(Reduction reduction) {
+    switch (reduction) {
+        case Reduction::Sum:
+            return torch::kSum;
+        case Reduction::None:
+            return torch::kNone;
+        case Reduction::Mean:
+        default:
+            return torch::kMean;
+    }
+}
+
+struct MSEOptions {
+    Reduction reduction{Reduction::Mean};
+    bool use_weight{false};
+};
+
+struct MSEDescriptor {
+    MSEOptions options{};
+};
+
+inline torch::Tensor compute(const MSEDescriptor& descriptor,
+                             const torch::Tensor& prediction,
+                             const torch::Tensor& target,
+                             const std::optional<torch::Tensor>& weight = std::nullopt) {
+    auto opts = torch::nn::functional::MSELossFuncOptions{};
+    opts = opts.reduction(to_torch_reduction(descriptor.options.reduction));
+    if (descriptor.options.use_weight) {
+        if (!weight.has_value() || !weight->defined()) {
+            throw std::invalid_argument("MSE loss configured to use weight but no weight tensor was provided.");
+        }
+        opts = opts.weight(*weight);
+    }
+    return torch::nn::functional::mse_loss(prediction, target, opts);
+}
+
+}  // namespace Thot::Loss::Details
+
 #endif //THOT_MSE_HPP

--- a/src/loss/loss.hpp
+++ b/src/loss/loss.hpp
@@ -1,25 +1,17 @@
 #ifndef THOT_LOSS_HPP
 #define THOT_LOSS_HPP
-// This file is an factory, must exempt it from any logical-code. For functions look into "/details"
-#include <cstddef>
-#include <type_traits>
+// This file is a factory, must exempt it from any logical-code. For functions look into "/details"
+
 #include "loss/details/mse.hpp"
 
-namespace thot::loss {
-    template <details::Reduction ReductionMode,
-              bool WithWeight = false,
-              std::size_t PredictionRank = 0,
-              std::size_t TargetRank = 0>
-    struct MSE {
-        using descriptor_type = details::MSEDescriptor<ReductionMode, WithWeight, PredictionRank, TargetRank>;
+namespace Thot::Loss {
+    using Reduction = Details::Reduction;
+    using MSEOptions = Details::MSEOptions;
+    using MSEDescriptor = Details::MSEDescriptor;
 
-        static constexpr details::Reduction reduction = descriptor_type::reduction;
-        static constexpr bool uses_weight = descriptor_type::uses_weight;
-        static constexpr std::size_t prediction_rank = descriptor_type::prediction_rank;
-        static constexpr std::size_t target_rank = descriptor_type::target_rank;
-
-        static constexpr descriptor_type descriptor() { return descriptor_type{}; }
-    };
+    [[nodiscard]] constexpr auto MSE(const MSEOptions& options = {}) noexcept -> MSEDescriptor {
+        return {options};
+    }
 }
 
 #endif //THOT_LOSS_HPP

--- a/src/optimizer/details/sgd.hpp
+++ b/src/optimizer/details/sgd.hpp
@@ -1,4 +1,33 @@
 #ifndef THOT_SGD_HPP
 #define THOT_SGD_HPP
 
+#include <torch/torch.h>
+
+namespace Thot::Optimizer::Details {
+
+struct SGDOptions {
+    double learning_rate{1e-2};
+    double momentum{0.0};
+    double dampening{0.0};
+    double weight_decay{0.0};
+    bool nesterov{false};
+    bool maximize{false};
+};
+
+struct SGDDescriptor {
+    SGDOptions options{};
+};
+
+inline torch::optim::SGDOptions to_torch_options(const SGDOptions& options) {
+    torch::optim::SGDOptions torch_options(options.learning_rate);
+    torch_options = torch_options.momentum(options.momentum);
+    torch_options = torch_options.dampening(options.dampening);
+    torch_options = torch_options.weight_decay(options.weight_decay);
+    torch_options = torch_options.nesterov(options.nesterov);
+    torch_options = torch_options.maximize(options.maximize);
+    return torch_options;
+}
+
+}  // namespace Thot::Optimizer::Details
+
 #endif //THOT_SGD_HPP

--- a/src/optimizer/optimizer.hpp
+++ b/src/optimizer/optimizer.hpp
@@ -1,12 +1,16 @@
 #ifndef THOT_OPTIMIZER_HPP
 #define THOT_OPTIMIZER_HPP
-// This file is an factory, must exempt it from any logical-code. For functions look into "/details"
+// This file is a factory, must exempt it from any logical-code. For functions look into "/details"
+
 #include "optimizer/details/sgd.hpp"
 
-namespace thot::optimizer {
-    template <typename... Options>
-    [[nodiscard]] constexpr auto make_sgd() noexcept {
-        return details::sgd_factory<Options...>{};
+namespace Thot::Optimizer {
+    using SGDOptions = Details::SGDOptions;
+    using SGDDescriptor = Details::SGDDescriptor;
+
+    [[nodiscard]] constexpr auto SGD(const SGDOptions& options = {}) noexcept -> SGDDescriptor {
+        return {options};
     }
 }
+
 #endif //THOT_OPTIMIZER_HPP


### PR DESCRIPTION
## Summary
- add a `Nott::Model` façade that wires fully connected layers, ReLU activations, SGD, and MSE loss together
- introduce descriptor factories for layers, activations, loss, initialization, and optimizer configuration
- implement ReLU activation behaviour, Xavier initialisation, and SGD option translation against libtorch

## Testing
- cmake -S . -B build *(fails: required CMake version 4.0 is higher than the available 3.28.3)*