### PR TITLE
Introduce loader abstraction and switch training loop to consume loaders

### DIFF
--- a/src/data/data.hpp
+++ b/src/data/data.hpp
@@ -2,6 +2,7 @@
 #define Nott_DATA_HPP
 // This file is an factory, must exempt it from any logical-code. For functions look into "/details"
 #include "details/generation.hpp"
+#include "loader/loader.hpp"
 #include "load/load.hpp"
 #include "transform/manipulation.hpp"
 #include "details/repair.hpp"

--- a/src/data/loader/loader.hpp
+++ b/src/data/loader/loader.hpp
@@ -1,0 +1,80 @@
+#ifndef Nott_DATA_LOADER_HPP
+#define Nott_DATA_LOADER_HPP
+
+#include <condition_variable>
+#include <cstddef>
+#include <deque>
+#include <mutex>
+#include <utility>
+
+#include <torch/torch.h>
+
+namespace Nott::Data::Loader {
+    using Batch = std::pair<torch::Tensor, torch::Tensor>;
+
+    class BaseLoader {
+    public:
+        virtual ~BaseLoader() = default;
+
+        virtual void start_epoch(std::size_t epoch) = 0;
+        virtual bool has_next() = 0;
+        virtual Batch next_batch() = 0;
+        [[nodiscard]] virtual std::size_t batch_size() const = 0;
+        [[nodiscard]] virtual bool drop_last() const = 0;
+        virtual void shutdown() = 0;
+    };
+
+    template<class T>
+    class ThreadSafeQueue {
+    public:
+        bool push(T value) {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (closed_) {
+                return false;
+            }
+            queue_.push_back(std::move(value));
+            condition_.notify_one();
+            return true;
+        }
+
+        bool try_pop(T &value) {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (queue_.empty()) {
+                return false;
+            }
+            value = std::move(queue_.front());
+            queue_.pop_front();
+            return true;
+        }
+
+        bool wait_pop(T &value) {
+            std::unique_lock<std::mutex> lock(mutex_);
+            condition_.wait(lock, [&] { return closed_ || !queue_.empty(); });
+            if (queue_.empty()) {
+                return false;
+            }
+            value = std::move(queue_.front());
+            queue_.pop_front();
+            return true;
+        }
+
+        void close() {
+            std::lock_guard<std::mutex> lock(mutex_);
+            closed_ = true;
+            condition_.notify_all();
+        }
+
+        [[nodiscard]] bool closed() const {
+            std::lock_guard<std::mutex> lock(mutex_);
+            return closed_;
+        }
+
+    private:
+        mutable std::mutex mutex_{};
+        std::condition_variable condition_{};
+        std::deque<T> queue_{};
+        bool closed_{false};
+    };
+}
+
+#endif //Nott_DATA_LOADER_HPP


### PR DESCRIPTION
### Motivation
- Add a generic, thread-safe data loader abstraction to support streaming/prefetching and custom data sources during training. 
- Enable training directly from producer/consumer loaders to decouple data pipeline from tensor slicing and make prefetch/buffering strategies reusable. 

### Description
- Added `Nott::Data::Loader` interface in `src/data/loader/loader.hpp` which defines `BaseLoader`, the `Batch` alias and a minimal `ThreadSafeQueue<T>` implementation (mutex + `condition_variable`).
- Exported the loader header via `src/data/data.hpp` and included it in `src/core.hpp` so core training code can consume loaders.
- Added a new `Model::train(Data::Loader::BaseLoader&, TrainOptions)` entry point that runs training using a loader and calls `loader.shutdown()` when finished.
- Introduced an internal adapter `TrainingDetails::TensorDatasetLoader` implementing `Data::Loader::BaseLoader` to wrap existing in-memory tensor datasets, and refactored `TrainingDetails::run_epochs` to accept a `Data::Loader::BaseLoader &` and iterate batches via `start_epoch`, `has_next`, and `next_batch` (keeping existing prefetch/buffering and graph/AMP logic).
- Updated the existing tensor-based `Model::train(torch::Tensor, torch::Tensor, TrainOptions)` flow to create a `TensorDatasetLoader` and route training through the loader-based `run_epochs` path.

### Testing
- No automated tests were executed as part of this change (no test run requested).